### PR TITLE
Switch to ByteStrings, attoparsec, blaze-builder

### DIFF
--- a/Network/Beanstalk.hs
+++ b/Network/Beanstalk.hs
@@ -653,7 +653,7 @@ listTubeUsed :: BeanstalkServer -- ^ Beanstalk server
              -> IO B.ByteString -- ^ Name of current used tube
 listTubeUsed bs = withMVar bs task
     where task s =
-              do send s ("list-tube-used\r\n")
+              do sendAll s ("list-tube-used\r\n")
                  response <- readLine s
                  checkForBeanstalkErrors response
                  let tubeName = parseUsedTube response


### PR DESCRIPTION
This fork is not API-compatible, which is unfortunate, but it fixes some bugs, and is generally faster. I've switched from Parsec to attoparsec, which solves the bug that hbeanstalk has when dealing with large numbers of tubes. This fork also removes the dependency on HsSyck, replacing it with an incremental parser that can take 1024-byte chunks from `recv`. Finally, I changed all calls to `send` to use `sendAll`, which guarantees that it will send everything you pass to it.

All tests pass, of course, and the required modifications to client code to support the ByteString API are fairly minimal. Is this a change that you'd be interested in?
