### PR TITLE
Updates package to use network rather than network-bytestring

### DIFF
--- a/hbeanstalk.cabal
+++ b/hbeanstalk.cabal
@@ -1,5 +1,5 @@
 Name:           hbeanstalk
-Version:        0.2.1
+Version:        0.2.3
 License:        BSD3
 License-file:   LICENSE
 Cabal-Version: >= 1.6
@@ -25,7 +25,7 @@ source-repository head
 Library
   ghc-options: -Wall
   Build-depends:  base >= 4 && < 5, network, containers >= 0.3.0.0,
-                  blaze-builder >= 0.2.1.0, network-bytestring >= 0.1.2.0,
+                  blaze-builder >= 0.2.1.0, network >= 2.3,
                   bytestring >= 0.9.1.7, attoparsec >= 0.8.3.0
 
   Exposed-modules:


### PR DESCRIPTION
network-bytestring was rolled into network (>=2.3); this updates hbeanstalk's .cabal to work with it.  All tests pass.
